### PR TITLE
Include all worn/carried items in worn weight

### DIFF
--- a/public/dataTypes.js
+++ b/public/dataTypes.js
@@ -79,7 +79,7 @@ Category.prototype.calculateSubtotal = function() {
         var item = this.library.getItemById(categoryItem.itemId);
         this.subtotal += item.weight*categoryItem.qty;
         if (categoryItem.worn) {
-            this.wornSubtotal += item.weight * ( (item.qty > 0) ? 1 : 0 );
+            this.wornSubtotal += item.weight*categoryItem.qty;
         }
         this.qtySubtotal += item.qty;
     }


### PR DESCRIPTION
@galenmaly -- Awesome tool! Enjoying building my pack lists with your site way more than some excel spreadsheet. Had a question about how total pack weight is calculated for worn/carried items with quantity greater than 1 -- right now only one of the items is included in the worn weight and the rest get put into the pack weight. Not sure if I am using the worn/carried option incorrectly.

Thanks again for your site.

Eric