### PR TITLE
Fix issue #16: mongojs issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,8 @@ var fs = require("fs");
 eval(fs.readFileSync(rootPath+'config.js')+'');
 
 var collections = ["users", "libraries"];
-var db = require("mongojs").connect(databaseUrl, collections);
+var mongojs = require('mongojs');
+var db = mongojs(databaseUrl, collections);
 
 var connect = require('connect');
 var cookieParser = require('cookie-parser');


### PR DESCRIPTION
Changed mongojs initialization to not use connect which no longer exists
with new versions.

Note: That with this change if a version is running an older version of mongojs before 1.0.1 it will need to be updated in order to work with this. Additionally there are no testing in place for lighterpack to ensure that everything works as intended when a package is updated.