### PR TITLE
Clicky charts

### DIFF
--- a/public/dataTypes.js
+++ b/public/dataTypes.js
@@ -170,10 +170,9 @@ List.prototype.render = function (args) {
     return out;
 }
 
-List.prototype.renderChart = function (doParent) {
+List.prototype.renderChart = function (type) {
     var chartData = { points: {}};
     var total = 0;
-    if (typeof doParent == "undefined") doParent = true;
 
     for (var i in this.categoryIds) {
         var category = this.library.getCategoryById(this.categoryIds[i]);
@@ -202,13 +201,12 @@ List.prototype.renderChart = function (doParent) {
                 if (item.qty > 1) name += " x "+item.qty;
                 if (!value) value = 0;
                 var percent = value / categoryTotal;
-                var tempItem =  { value: value, id: item.id, name: name, color: color, percent: percent };
-                if (doParent) tempItem.parent = tempCategory;
+                var tempItem =  { value: value, id: item.id, name: name, color: color, parent: tempCategory, percent: percent };
+                tempItem.parent = tempCategory;
                 points[j] = tempItem;
             }
             var percent = categoryTotal / total;
-            var tempCategoryData = {points: points, color: category.color, id:category.id, name:category.name, total: categoryTotal, percent: percent, visiblePoints: false};
-            if (doParent) tempCategoryData.parent = chartData;
+            var tempCategoryData = {parent: chartData, points: points, color: category.color, id:category.id, name:category.name, total: categoryTotal, percent: percent, visiblePoints: false};
             extend(tempCategory, tempCategoryData);
             chartData.points[i] = tempCategory;
         }
@@ -409,8 +407,8 @@ Library.prototype.renderLibrary = function(template) {
     return out;
 }
 
-Library.prototype.renderChart = function() {
-    return this.lists[this.defaultListId].renderChart();
+Library.prototype.renderChart = function(type) {
+    return this.lists[this.defaultListId].renderChart(type);
 }
 
 Library.prototype.renderTotals = function(totalsTemplate, unitSelectTemplate) {

--- a/public/dataTypes.js
+++ b/public/dataTypes.js
@@ -178,7 +178,16 @@ List.prototype.renderChart = function (type) {
         var category = this.library.getCategoryById(this.categoryIds[i]);
         if (category) {
             category.calculateSubtotal();
-            total += category.subtotal;
+
+            if (type === 'lpConsumableWeight') {
+              total += category.consumableSubtotal;
+            } else if (type === 'lpWornWeight') {
+              total += category.wornSubtotal;
+            } else if (type === 'lpPackWeight') {
+              total += (category.subtotal - (category.consumableSubtotal + category.wornSubtotal));
+            } else {
+              total += category.subtotal;
+            }
         }
     }
 
@@ -188,7 +197,18 @@ List.prototype.renderChart = function (type) {
         var category = this.library.getCategoryById(this.categoryIds[i]);
         if (category) {
             var points = {};
-            var categoryTotal = category.subtotal;
+
+            var categoryTotal;
+            if (type === 'lpConsumableWeight') {
+              categoryTotal = category.consumableSubtotal;
+            } else if (type === 'lpWornWeight') {
+              categoryTotal = category.wornSubtotal;
+            } else if (type === 'lpPackWeight') {
+              categoryTotal = (category.subtotal - (category.consumableSubtotal + category.wornSubtotal));
+            } else {
+              categoryTotal = category.subtotal;
+            }
+
             var tempColor = category.color || getColor(i);
             category.displayColor = rgbToString(tempColor);
             var tempCategory = {};

--- a/public/dataTypes.js
+++ b/public/dataTypes.js
@@ -179,11 +179,11 @@ List.prototype.renderChart = function (type) {
         if (category) {
             category.calculateSubtotal();
 
-            if (type === 'lpConsumableWeight') {
+            if (type === 'consumable') {
               total += category.consumableSubtotal;
-            } else if (type === 'lpWornWeight') {
+            } else if (type === 'worn') {
               total += category.wornSubtotal;
-            } else if (type === 'lpPackWeight') {
+            } else if (type === 'pack') {
               total += (category.subtotal - (category.consumableSubtotal + category.wornSubtotal));
             } else {
               total += category.subtotal;
@@ -199,11 +199,11 @@ List.prototype.renderChart = function (type) {
             var points = {};
 
             var categoryTotal;
-            if (type === 'lpConsumableWeight') {
+            if (type === 'consumable') {
               categoryTotal = category.consumableSubtotal;
-            } else if (type === 'lpWornWeight') {
+            } else if (type === 'worn') {
               categoryTotal = category.wornSubtotal;
-            } else if (type === 'lpPackWeight') {
+            } else if (type === 'pack') {
               categoryTotal = (category.subtotal - (category.consumableSubtotal + category.wornSubtotal));
             } else {
               categoryTotal = category.subtotal;

--- a/public/edit.js
+++ b/public/edit.js
@@ -181,8 +181,8 @@ editLists = function() {
         });
     }
 
-    function updateChart() {
-        var chartData = library.renderChart();
+    function updateChart(type) {
+        var chartData = library.renderChart(type);
 
         if (chartData) {
             if (chart) {
@@ -496,6 +496,15 @@ editLists = function() {
                 updateItem($(this).parents(".lpItem"));
                 updateSubtotals();
             }
+        });
+
+        $list.on("click", ".lpTotals .lpFooter", function() {
+          var type = this.className.match(/\blp[A-Z][a-z]+Weight\b/);
+          if (type && type[0]) {
+            updateChart(type[0]);
+          } else {
+            updateChart();
+          }
         });
 
         $("#hamburger").off("click").on("click", function() {

--- a/public/edit.js
+++ b/public/edit.js
@@ -162,22 +162,9 @@ editLists = function() {
         var list = library.getListById(library.defaultListId);
 
         if (list.categoryIds.length) {
-            var chartData = library.renderChart();
-
             $("#getStarted").hide();
             $("#totalsContainer").css("visibility", "visible");
-            $chartContainer.css("visibility", "visible");
-
-            if (chartData) {
-                if (chart) {
-                    chart.update({processedData: chartData});
-                } else {
-                    chart = pies({processedData: chartData, container: $chartContainer, hoverCallback: chartHover});    
-                }
-                $chartContainer.css("visibility", "visible");
-            } else {
-                $chartContainer.css("visibility", "hidden");
-            }
+            updateChart();
             $(".lpTotalsContainer").html(library.renderTotals(totalsTemplate, unitSelectTemplate));
         } else {
             $("#getStarted").show();
@@ -192,6 +179,21 @@ editLists = function() {
             $(".lpSubtotalUnit", this).text(category.subtotalUnit);
             $(".lpQtySubtotal", this).text(category.qtySubtotal);
         });
+    }
+
+    function updateChart() {
+        var chartData = library.renderChart();
+
+        if (chartData) {
+            if (chart) {
+                chart.update({processedData: chartData});
+            } else {
+                chart = pies({processedData: chartData, container: $chartContainer, hoverCallback: chartHover});    
+            }
+            $chartContainer.css("visibility", "visible");
+        } else {
+            $chartContainer.css("visibility", "hidden");
+        }
     }
 
     function chartHover(chartItem) {

--- a/public/edit.js
+++ b/public/edit.js
@@ -499,9 +499,9 @@ editLists = function() {
         });
 
         $list.on("click", ".lpTotals .lpFooter", function() {
-          var type = this.className.match(/\blp[A-Z][a-z]+Weight\b/);
-          if (type && type[0]) {
-            updateChart(type[0]);
+          var type = this.dataset.weightType;
+          if (type) {
+            updateChart(type)
           } else {
             updateChart();
           }

--- a/templates/t_totals.mustache
+++ b/templates/t_totals.mustache
@@ -32,7 +32,7 @@
                 <span class="lpTotalUnit">{{{totalUnit}}}</span>
             </span>
         </li>
-        <li class="lpRow lpFooter lpBreakdown lpConsumableWeight">
+        <li data-weight-type="consumable" class="lpRow lpFooter lpBreakdown lpConsumableWeight">
             <span class="lpCell"></span>
             <span class="lpCell lpSubtotal">
                 Consumable
@@ -42,7 +42,7 @@
                 <span class="lpSubtotalUnit">{{subtotalUnit}}</span>
             </span>
         </li>
-        <li class="lpRow lpFooter lpBreakdown lpWornWeight">
+        <li data-weight-type="worn" class="lpRow lpFooter lpBreakdown lpWornWeight">
             <span class="lpCell"></span>
             <span class="lpCell lpSubtotal">
                 Worn
@@ -52,7 +52,7 @@
                 <span class="lpSubtotalUnit">{{subtotalUnit}}</span>
             </span>
         </li>
-        <li class="lpRow lpFooter lpBreakdown lpPackWeight">
+        <li data-weight-type="pack" class="lpRow lpFooter lpBreakdown lpPackWeight">
             <span class="lpCell"></span>
             <span class="lpCell lpSubtotal">
                 Pack Weight


### PR DESCRIPTION
Love this app - been using it for the last year and it's really helped me track trips and slim down my base weight.

One feature that I've been looking for is the ability to update the chart based on the 'type' of weight. For example, seeing a breakdown of my total weight is nice, but being able to see a pie chart of only my pack weight (no consumable or worn) would be more useful to drill down offending categories when trying to cut down base weight on trips.

I'm not sure if this is implemented quite the way you'd like, or if allowing consumable/worn chart updates is as handy as pack weight. Totally game to make any suggested changes or, if you don't think this fits with your vision of app usage, I won't be offended if you just close w/o merging.