### PR TITLE
added scrollbar for listContainer

### DIFF
--- a/public/css/edit.css
+++ b/public/css/edit.css
@@ -111,6 +111,8 @@
 }
 #scrollable #listContainer {
   flex: 0 0 auto;
+  max-height: 400px;
+  overflow-y: auto;
 }
 #scrollable #libraryContainer {
   display: flex;

--- a/public/css/edit.less
+++ b/public/css/edit.less
@@ -119,6 +119,8 @@
 
     #listContainer {
         flex: 0 0 auto;
+        max-height: 400px;
+        overflow-y: auto;
     }
 
     #libraryContainer {


### PR DESCRIPTION
Made the listContainer scrollable when having more lists than previously allowed. Useful for keeping a long history of lists for sharing and comparison over time.
