### PR TITLE
Introduce `bindings' config to specify which interfaces to listen on

### DIFF
--- a/app.js
+++ b/app.js
@@ -649,11 +649,16 @@ function init() {
 
 init();
 
-// Default port is 3000
-app.listen(config.get('port'));
-
 var d = new Date();
 var time = d.toString().substr(0,24);
 console.log("-------");
 console.log(time);
-console.log('Listening on port ' + config.get('port'));
+
+// Default port is 3000; we can have multiple bindings
+config.get('bindings').map(
+    function(bind) {
+	app.listen(config.get('port'),bind);
+	console.log('Listening on [' + bind + ']:' +config.get('port'));
+    }
+)
+

--- a/config/default.json
+++ b/config/default.json
@@ -11,6 +11,16 @@
     /* Port to run node server on */
     "port"          : 3000,
 
+    /* By default bind to all available interfaces on both ipv6 and ipv4
+       Each element of `bindings` gets passed to to `app.listen(port, element)`
+
+       Examples:
+       Both ipv4+ipv6 on all interfaces: [""] 
+       Only ipv6, on all interfaces    : ["::"]
+       Both loopback interfaces        : ["127.0.0.1","::1"]
+    */
+    "bindings"      : [""],
+
     /* Mongo connect URI */
     "databaseUrl"   : "localhost/lighterpack",
 


### PR DESCRIPTION
The typical usecase is to only listen on the local loopback interface if
lighterpack runs behind nginx or another reverse proxy solution.

The default for `bindings` has been set to "" (empty string) which means
the program will bind to all available interface on both ipv4 and ipv6