### PR TITLE
add library.currencySymbol to template

### DIFF
--- a/templates/t_categoryEdit.mustache
+++ b/templates/t_categoryEdit.mustache
@@ -15,7 +15,7 @@
             <span class="lpAddItemCell">
                 <a href="#" class="lpAdd lpAddItem"><i class="lpSprite lpSpriteAdd"></i>Add new item</a>
             </span>
-            <span class="lpPriceCell lpNumber"><div class="lpPriceSubtotal"><span class="lpCurrencySymbol"></span><span class="lpDisplayPriceSubtotal">{{priceSubtotal}}</span></div></span>
+            <span class="lpPriceCell lpNumber"><div class="lpPriceSubtotal"><span class="lpCurrencySymbol">{{library.currencySymbol}}</span><span class="lpDisplayPriceSubtotal">{{priceSubtotal}}</span></div></span>
             <span class="lpWeightCell lpNumber"><div class="lpSubtotal"><span class="lpDisplaySubtotal">{{displaySubtotal}}</span> <span class="lpSubtotalUnit">{{subtotalUnit}}</span></div></span>
             <span class="lpQtyCell"><div class="lpSubtotal"><span class="lpQtySubtotal">{{qtySubtotal}}</span></div></span>
             <span class="lpRemoveCell"></span>


### PR DESCRIPTION
fixes a small bug where the currency symbol wasn't showing up if a new category was created.