### PR TITLE
Worn Subtotal handles quantities of > 1 as worn weight not base weight

### DIFF
--- a/public/js/dataTypes.js
+++ b/public/js/dataTypes.js
@@ -85,7 +85,7 @@ Category.prototype.calculateSubtotal = function() {
         var item = this.library.getItemById(categoryItem.itemId);
         this.subtotal += item.weight*categoryItem.qty;
         if (categoryItem.worn) {
-            this.wornSubtotal += item.weight * ( (item.qty > 0) ? 1 : 0 );
+            this.wornSubtotal += item.weight * item.qty;
         }
         if (categoryItem.consumable) {
             this.consumableSubtotal += item.weight * item.qty;


### PR DESCRIPTION
When the quantity of a worn item is > 1 the weight of all additional items is added to base weight (because it's counted in total) but not reflected in worn weight. So, if you have two trekking poles only one is counted as worn and your overall base weight goes up.