### PR TITLE
Add totalPackWeight (totalWeight - totalWornWeight) to list summary.

### DIFF
--- a/client/components/list-summary.vue
+++ b/client/components/list-summary.vue
@@ -80,6 +80,19 @@
                         <span class="lpSubtotalUnit">{{ library.totalUnit }}</span>
                     </span>
                 </li>
+                <li v-if="list.totalPackWeight !== list.totalWeight && list.totalPackWeight !== list.totalBaseWeight" data-weight-type="base" class="lpRow lpFooter lpBreakdown lpBaseWeight">
+                    <span class="lpCell" />
+                    <span class="lpCell lpSubtotal" :title="$options.filters.displayWeight(list.totalPackWeight, library.totalUnit) + ' ' + library.totalUnit + ' pack weight (consumable + base weight)'">
+                        Pack Weight
+                    </span>
+                    <span v-if="library.optionalFields['price']" class="lpCell lpNumber" />
+                    <span class="lpCell lpNumber lpSubtotal">
+                        <span class="lpDisplaySubtotal" :mg="list.totalPackWeight" :title="$options.filters.displayWeight(list.totalPackWeight, library.totalUnit) + ' ' + library.totalUnit + ' pack weight (consumable + base weight)'">
+                            {{ list.totalPackWeight | displayWeight(library.totalUnit) }}
+                        </span>
+                        <span class="lpSubtotalUnit">{{ library.totalUnit }}</span>
+                    </span>
+                </li>
                 <li v-if="list.totalWornWeight || list.totalConsumableWeight" data-weight-type="base" class="lpRow lpFooter lpBreakdown lpBaseWeight">
                     <span class="lpCell" />
                     <span class="lpCell lpSubtotal" :title="$options.filters.displayWeight(list.totalPackWeight, library.totalUnit) + ' ' + library.totalUnit + ' pack weight (consumable + base weight)'">
@@ -87,7 +100,7 @@
                     </span>
                     <span v-if="library.optionalFields['price']" class="lpCell lpNumber" />
                     <span class="lpCell lpNumber lpSubtotal">
-                        <span class="lpDisplaySubtotal" :mg="list.totalBaseWeight" :title="$options.filters.displayWeight(list.totalPackWeight, library.totalUnit) + ' ' + library.totalUnit + ' pack weight (consumable + base weight)'">
+                        <span class="lpDisplaySubtotal" :mg="list.totalBaseWeight" :title="$options.filters.displayWeight(list.totalBaseWeight, library.totalUnit) + ' ' + library.totalUnit + ' pack weight (consumable + base weight)'">
                             {{ list.totalBaseWeight | displayWeight(library.totalUnit) }}
                         </span>
                         <span class="lpSubtotalUnit">{{ library.totalUnit }}</span>

--- a/server/views.js
+++ b/server/views.js
@@ -404,6 +404,7 @@ const renderListTotals = function (list, totalsTemplate, unitSelectTemplate, uni
     let totalWornWeight = 0;
     let totalConsumableWeight = 0;
     let totalPackWeight = 0;
+    let totalBaseWeight = 0;
     let totalQty = 0;
     let totalPrice = 0;
     let totalConsumablePrice = 0;
@@ -427,7 +428,8 @@ const renderListTotals = function (list, totalsTemplate, unitSelectTemplate, uni
         }
     }
 
-    totalPackWeight = totalWeight - (totalWornWeight + totalConsumableWeight);
+    totalBaseWeight = totalWeight - (totalWornWeight + totalConsumableWeight);
+    totalPackWeight = totalWeight - totalWornWeight;
 
     out.totalWeight = totalWeight;
     out.totalWeightDisplay = weightUtils.MgToWeight(totalWeight, unit);
@@ -437,9 +439,12 @@ const renderListTotals = function (list, totalsTemplate, unitSelectTemplate, uni
     out.totalWornWeightDisplay = weightUtils.MgToWeight(totalWornWeight, unit);
     out.totalConsumableWeight = totalConsumableWeight;
     out.totalConsumableWeightDisplay = weightUtils.MgToWeight(totalConsumableWeight, unit);
+    out.totalBaseWeight = totalBaseWeight;
     out.totalPackWeight = totalPackWeight;
     out.totalPackWeightDisplay = weightUtils.MgToWeight(totalPackWeight, unit);
-    out.shouldDisplayPackWeight = totalPackWeight !== totalWeight;
+    out.totalBaseWeightDisplay = weightUtils.MgToWeight(totalBaseWeight, unit);
+    out.shouldDisplayPackWeight = totalPackWeight !== totalBaseWeight && totalPackWeight !== totalWeight;
+    out.shouldDisplayBaseWeight = totalBaseWeight !== totalWeight;
     out.totalQty = totalQty;
     out.totalPrice = totalPrice;
     out.totalPriceDisplay = totalPrice ? totalPrice.toFixed(2) : '';

--- a/templates/t_totals.mustache
+++ b/templates/t_totals.mustache
@@ -74,7 +74,7 @@
         <li data-weight-type="base" class="lpRow lpFooter lpBreakdown lpPackWeight">
             <span class="lpCell"></span>
             <span class="lpCell lpSubtotal">
-                Base Weight
+                Pack Weight
             </span>
             {{#showPrices}}
             <span class="lpCell"></span>
@@ -85,4 +85,19 @@
             </span>
         </li>
     {{/shouldDisplayPackWeight}}
+    {{#shouldDisplayBaseWeight}}
+        <li data-weight-type="base" class="lpRow lpFooter lpBreakdown lpPackWeight">
+            <span class="lpCell"></span>
+            <span class="lpCell lpSubtotal">
+                Base Weight
+            </span>
+            {{#showPrices}}
+                <span class="lpCell"></span>
+            {{/showPrices}}
+            <span class="lpCell lpNumber lpSubtotal">
+                <span class="lpDisplaySubtotal" mg="{{totalBaseWeight}}">{{totalBaseWeightDisplay}}</span>
+                <span class="lpSubtotalUnit">{{subtotalUnit}}</span>
+            </span>
+        </li>
+    {{/shouldDisplayBaseWeight}}
 </ul>


### PR DESCRIPTION
Fixes #151 
For the Vue client, the total pack weight was calculated but not shown in the list summary component.
I also added it to the mustache template.
The total pack weight is only shown if it differs from the total weight and the total base weight.