### PR TITLE
Don't create a new empty item for new categories

### DIFF
--- a/client/store/store.js
+++ b/client/store/store.js
@@ -88,13 +88,11 @@ const store = new Vuex.Store({
         },
         newCategory(state, list) {
             const category = state.library.newCategory({ list, _isNew: true });
-            const item = state.library.newItem({ category });
             state.library.getListById(state.library.defaultListId).calculateTotals();
         },
         newList(state) {
             const list = state.library.newList();
             const category = state.library.newCategory({ list });
-            const item = state.library.newItem({ category });
             list.calculateTotals();
             state.library.defaultListId = list.id;
         },


### PR DESCRIPTION
fixes #173 
Empty items are not created when creating a new category in a list, and when creating a new list.