### PR TITLE
Persist category colors when copying a list

### DIFF
--- a/client/dataTypes.js
+++ b/client/dataTypes.js
@@ -456,6 +456,7 @@ Library.prototype.copyList = function (id) {
         const copiedCategory = this.newCategory({ list: copiedList });
 
         copiedCategory.name = oldCategory.name;
+        copiedCategory.color = oldCategory.color;
 
         for (const j in oldCategory.categoryItems) {
             copiedCategory.addItem(oldCategory.categoryItems[j]);


### PR DESCRIPTION
I know the contributing guide says no new features, but hoping you'll make an exception 🙏

It's really hard to compare the pie graphs between multiple lists when the colors are never the same, and because of the color picker that lighterpack uses, users can't even copy/paste RGB/Hex codes to make them consistent.