### PR TITLE
Enter-key to add items

### DIFF
--- a/client/components/category.vue
+++ b/client/components/category.vue
@@ -23,7 +23,7 @@
                 <span class="lpQtyCell">qty</span>
                 <span class="lpRemoveCell"><a class="lpRemove lpRemoveCategory" title="Remove this category" @click="removeCategory(category)"><i class="lpSprite lpSpriteRemove" /></a></span>
             </li>
-            <item v-for="itemContainer in itemContainers" :key="itemContainer.item.id" :item-container="itemContainer" :category="category" />
+            <item v-for="itemContainer in itemContainers" :key="itemContainer.item.id" :item-container="itemContainer" :category="category" @keyup.enter.native="newItem" />
             <li class="lpFooter lpItemsFooter">
                 <span class="lpAddItemCell">
                     <a class="lpAdd lpAddItem" @click="newItem"><i class="lpSprite lpSpriteAdd" />Add new item</a>


### PR DESCRIPTION
For feature request #199
Use Tab as per usual to fill in the cells, Enter to add a new row/item.