### PR TITLE
Add 'In percent' per category in the summary

### DIFF
--- a/client/components/list-summary.vue
+++ b/client/components/list-summary.vue
@@ -26,6 +26,9 @@
                     <span class="lpCell">
                         Weight
                     </span>
+                    <span class="lpCell">
+                        In percents 
+                    </span>
                 </li>
                 <li v-for="category in categories" :key="category.id" :class="{'hover': category.activeHover, 'lpTotalCategory lpRow': true}">
                     <span class="lpCell lpLegendCell">
@@ -39,6 +42,9 @@
                     </span>
                     <span class="lpCell lpNumber">
                         <span class="lpDisplaySubtotal" :mg="category.subtotalWeight">{{ category.subtotalWeight | displayWeight(library.totalUnit) }}</span> <span class="lpSubtotalUnit">{{ library.totalUnit }}</span>
+                    </span>
+                    <span class="lpCell lpNumber">
+                        <span class="lpDisplayProcent" :mg="category.subtotalWeight / list.totalPackWeight * 100">{{ category.subtotalWeight / list.totalPackWeight * 100 }} %</span>
                     </span>
                 </li>
                 <li class="lpRow lpFooter lpTotal">


### PR DESCRIPTION
## Summary
Add `%` information in the summary per category.

## Visual changes
* "In percent" cell added to the summary. 
<img width="999" alt="image" src="https://user-images.githubusercontent.com/18559953/184426724-67419d3b-7c6a-4d85-be69-a03b8933dd40.png">
