### PR TITLE
Mobile + Safari fixes

### DIFF
--- a/_index.html
+++ b/_index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html class="lp">
     <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <link rel="preload" href="/fonts/open-sans-latin.woff2" as="font" type="font/woff2" crossorigin />
          {{styles}}
         <link rel="shortcut icon" href="/favicon.png" />

--- a/client/utils/focus.js
+++ b/client/utils/focus.js
@@ -26,11 +26,16 @@ export const emptyIfZero = {
             }
         });
 
-        // Once the user types, stop forcing the field empty so their input
-        // survives the re-render savePrice/saveWeight triggers.
-        el.addEventListener('input', () => {
+        // Stop forcing the field empty before the browser inserts the first
+        // character. Waiting for `input` is too late on iOS: saveWeight can
+        // trigger a Vue update earlier in that event, and updated() would then
+        // clear the character while this flag was still set.
+        const stopEmptying = () => {
             el._emptyIfZero = false;
-        });
+        };
+        el.addEventListener('beforeinput', stopEmptying);
+        // Keep input as a fallback for browsers without beforeinput.
+        el.addEventListener('input', stopEmptying);
 
         el.addEventListener('blur', () => {
             el._emptyIfZero = false;
@@ -45,7 +50,9 @@ export const emptyIfZero = {
     // bound zero, undoing the empty above. Re-clear it so a freshly-focused
     // zero field stays empty until the user actually types.
     updated(el) {
-        if (el._emptyIfZero && document.activeElement === el) {
+        if (el._emptyIfZero
+            && document.activeElement === el
+            && (el.value === '0' || el.value === '0.00')) {
             el.value = '';
         }
     },

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html class="lp">
     <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <link rel="preload" href="/fonts/open-sans-latin.woff2" as="font" type="font/woff2" crossorigin />
         <link rel="shortcut icon" href="/favicon.png" />
         <title>LighterPack</title>

--- a/test/e2e/mobile.spec.ts
+++ b/test/e2e/mobile.spec.ts
@@ -117,6 +117,18 @@ test.describe('Phone item rows', () => {
     await expect(editor.getByPlaceholder('Name', { exact: true })).toHaveValue('');
   });
 
+  test('keeps the first weight character typed into a new item', async ({ page }) => {
+    await signUpWithList(page);
+
+    await page.getByText('Add new item', { exact: true }).first().tap();
+    const weight = page.getByTestId('item-editor').getByTestId('item-weight');
+
+    await weight.tap();
+    await weight.pressSequentially('7');
+
+    await expect(weight).toHaveValue('7');
+  });
+
   test('tapping a row opens exactly one editor, and tapping outside closes it', async ({ page }) => {
     await signUpWithList(page);
 


### PR DESCRIPTION
Hello, I noticed a bug + potential UX improvement with the new update. The screen recordings were taken this morning on the production site. I see you are not looking for contributions, feel free to close if these are not desired. Thanks for your time!

### Viewport zoom on focus on iOS
https://github.com/user-attachments/assets/f3f0d5e0-ae29-4491-b74e-11b9281d23d5

Adds `maximum-scale=1` to the viewport meta tag to prevent iOS from zooming when you focus an input on mobile. On most phones there's no downside to this, but on some Android phones this will prevent pinch-to-zoom, so potential a11y tradeoff there. I can remove this from the PR if needed.

### Fix first character in weight input being deleted on Safari
https://github.com/user-attachments/assets/9c8d7b00-bc81-4c53-92bc-3c2270ea7e6c

The clear-if-zero directive incorrectly runs after you type the first character in the weight input and deletes it. This happens on Safari on both desktop and mobile. 
