### PR TITLE
Add option to copy a list without linking items

### DIFF
--- a/client/components/copy-list.vue
+++ b/client/components/copy-list.vue
@@ -12,7 +12,7 @@
             </select>
         </div>
         <toggle id="copyListLinkItems" v-model="linkItems">
-            Link items (changing an item in either list will affect the other)
+            Link lists (updating an item in one list will affect the other)
         </toggle>
         <div class="lpButtons">
             <a id="copyConfirm" class="lpButton" @click="copyList">Copy List</a>

--- a/client/components/copy-list.vue
+++ b/client/components/copy-list.vue
@@ -11,9 +11,9 @@
                 </option>
             </select>
         </div>
-        <p class="lpWarning">
-            <b>Note:</b> Copying a list will link the items between your lists. Updating an item in one list will alter that item in all other lists that item is in.
-        </p>
+        <toggle id="copyListLinkItems" v-model="linkItems">
+            Link items (changing an item in either list will affect the other)
+        </toggle>
         <div class="lpButtons">
             <a id="copyConfirm" class="lpButton" @click="copyList">Copy List</a>
             <a class="lpHref" @click="$emit('hide')">Cancel</a>
@@ -23,11 +23,13 @@
 
 <script>
 import modal from './modal.vue';
+import toggle from './toggle.vue';
 
 export default {
     name: 'CopyList',
     components: {
         modal,
+        toggle,
     },
     props: {
         shown: {
@@ -42,6 +44,7 @@ export default {
             // the select opens on a prompt instead of a blank row. Still falsy,
             // so copyList's guard reads the same.
             listId: '',
+            linkItems: true,
         };
     },
     computed: {
@@ -57,7 +60,7 @@ export default {
         },
         copyList() {
             if (!this.listId) return;
-            this.$store.commit('copyList', this.listId);
+            this.$store.commit('copyList', { listId: this.listId, linkItems: this.linkItems });
             this.$emit('hide');
         },
     },
@@ -68,10 +71,10 @@ export default {
 @import "../css/_globals";
 
 #copyListDialog {
-    // The note is an aside between the picker and the actions, so it wants the
-    // same breathing room on both sides rather than the tighter default the
-    // modal gives a run of paragraphs.
-    .lpWarning {
+    // The toggle is an aside between the picker and the actions, so it wants
+    // the same breathing room on both sides rather than the tighter default
+    // the modal gives.
+    .lpToggle {
         margin: 0 0 $spacingMedium;
     }
 }

--- a/client/dataTypes.js
+++ b/client/dataTypes.js
@@ -474,11 +474,15 @@ Library.prototype.removeList = function (id) {
     }
 };
 
-Library.prototype.copyList = function (id) {
+Library.prototype.copyList = function (id, { linkItems = true } = {}) {
     const oldList = this.getListById(id);
     if (!oldList) return;
 
     const copiedList = this.newList();
+
+    // When unlinking, an item appearing several times in the source list maps
+    // to a single new item, so the copy is still internally consistent.
+    const copiedItemIds = {};
 
     copiedList.name = `Copy of ${oldList.name}`;
     copiedList.optionalFields = assignIn({}, oldList.optionalFields);
@@ -489,7 +493,19 @@ Library.prototype.copyList = function (id) {
         copiedCategory.name = oldCategory.name;
 
         for (const j in oldCategory.categoryItems) {
-            copiedCategory.addItem(oldCategory.categoryItems[j]);
+            const oldCategoryItem = oldCategory.categoryItems[j];
+            let itemId = oldCategoryItem.itemId;
+            if (!linkItems) {
+                if (!(itemId in copiedItemIds)) {
+                    const copiedItem = this.newItem({});
+                    const copiedId = copiedItem.id;
+                    assignIn(copiedItem, this.getItemById(itemId));
+                    copiedItem.id = copiedId;
+                    copiedItemIds[itemId] = copiedId;
+                }
+                itemId = copiedItemIds[itemId];
+            }
+            copiedCategory.addItem(assignIn({}, oldCategoryItem, { itemId }));
         }
     }
 

--- a/client/store/store.js
+++ b/client/store/store.js
@@ -221,8 +221,8 @@ const store = createStore({
             state.library.forkItem(args.itemId, args.listId);
             state.library.getListById(state.library.defaultListId).calculateTotals();
         },
-        copyList(state, listId) {
-            const copiedList = state.library.copyList(listId);
+        copyList(state, { listId, linkItems }) {
+            const copiedList = state.library.copyList(listId, { linkItems });
             state.library.defaultListId = copiedList.id;
         },
         importCSV(state, importData) {

--- a/test/unit/dataTypes.test.js
+++ b/test/unit/dataTypes.test.js
@@ -187,6 +187,34 @@ describe('per-list settings', () => {
         assert.deepEqual(copy.optionalFields, library.lists[0].optionalFields);
         assert.notEqual(copy.optionalFields, library.lists[0].optionalFields);
     });
+
+    test('copyList shares items with the source list by default', () => {
+        const library = new Library();
+        const item = library.items[0];
+
+        const copy = library.copyList(library.lists[0].id);
+
+        const copiedCategory = library.getCategoryById(copy.categoryIds[0]);
+        assert.equal(copiedCategory.categoryItems[0].itemId, item.id);
+    });
+
+    test('copyList with linkItems false copies items instead of sharing them', () => {
+        const library = new Library();
+        const item = library.items[0];
+        item.name = 'Tent';
+        item.weight = 100;
+
+        const copy = library.copyList(library.lists[0].id, { linkItems: false });
+
+        const copiedCategory = library.getCategoryById(copy.categoryIds[0]);
+        const copiedItem = library.getItemById(copiedCategory.categoryItems[0].itemId);
+        assert.notEqual(copiedItem.id, item.id);
+        assert.equal(copiedItem.name, 'Tent');
+        assert.equal(copiedItem.weight, 100);
+
+        item.weight = 200;
+        assert.equal(copiedItem.weight, 100, 'editing the original must not affect the copy');
+    });
 });
 
 describe('Category.load repair', () => {


### PR DESCRIPTION
Makes it possible to unlink lists when copying them. I find the linked list behavior a bit unintuitive and I think it would be nice to disable when copying.

This adds a *"Link lists (updating an item in one list will affect the other)"** option to the copy dialog, checked by default.

- **Checked** (default): current behavior, unchanged — the copy shares items with the source list.
- **Unchecked**: every item in the source list is copied to a new, independent item, so the two lists can be edited without affecting each other.

Thanks for making lighterpack. It's really great. This is a Claude-generated change which took zero of my time, so feel free to say no or ignore if you don't like the feature. I'm also happy to rework in some other form if you prefer.

**Testing:** existing tests pass and 2 new tests also pass.